### PR TITLE
Add a warning when no repository was found

### DIFF
--- a/src/git-hub-adapter.service.ts
+++ b/src/git-hub-adapter.service.ts
@@ -141,6 +141,12 @@ export class GitHubAdapterService implements GitAdapter {
       },
     )
 
+    if (!response.data.data.repository) {
+      throw new Error(
+        `No repository found "${this.gitRepositoryOptions.repositoryOwner}/${this.gitRepositoryOptions.repositoryName}"`,
+      )
+    }
+
     const lastCommit =
       response.data.data.repository.ref?.target?.oid ??
       response.data.data.repository.object?.oid ??


### PR DESCRIPTION
This PR adds a check and throws an error when not repository was found for the given options.

Before, the code was assuming that `response.data.data.repository` is always available which is not the case if you have a typo in your github options (which I had).
It was throwing a "cannot read from undefined" error instead which isn't very helpful for users.