### PR TITLE
fix:  esm-compatibility

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -9,6 +9,10 @@ const jestConfig: Config = {
   transform: {
     '^.+\\.ts$': 'ts-jest',
   },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.ts$': '$1',
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
 }
 
 export default jestConfig

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "npm run build:cjs && npm run build:esm && npm run build:types",
     "build:cjs": "tsc --project tsconfig.build.cjs.json",
-    "build:esm": "tsc --project tsconfig.build.esm.json",
+    "build:esm": "tsc --project tsconfig.build.esm.json && echo '{\"type\":\"module\"}' > dist/esm/package.json",
     "build:types": "tsc --project tsconfig.build.types.json",
     "lint": "eslint \"{src,tests}/**/*.ts\"",
     "test": "jest",

--- a/src/axios/cached-instance.ts
+++ b/src/axios/cached-instance.ts
@@ -4,7 +4,7 @@ import {
   setupCache,
 } from 'axios-cache-interceptor'
 import axios from 'axios'
-import { cacheKeyGenerator } from './cache-key-generator'
+import { cacheKeyGenerator } from './cache-key-generator.ts'
 
 export const QUERY_CACHE_SECONDS = 10 * 60
 

--- a/src/github-adapter.ts
+++ b/src/github-adapter.ts
@@ -6,19 +6,19 @@ import {
   ErrorCode,
   GitAdapterError,
 } from '@commitspark/git-adapter'
-import { GitHubRepositoryOptions } from './index'
+import { GitHubRepositoryOptions } from './index.ts'
 import {
   createSingleBlobContentQuery,
   createCommitMutation,
   createLatestCommitQuery,
-} from './github-api/graphql-query-factory'
-import { convertEntriesToActions } from './util/entries-to-actions-converter'
-import { getPathEntryFolder, getPathSchema } from './util/path-factory'
-import { createEntriesFromFileContent } from './util/entry-factory'
-import { handleGraphQLErrors, handleHttpErrors } from './errors'
-import { getEntryContent } from './github-api/get-entry-content'
-import { getFilePaths } from './github-api/get-file-paths'
-import { GITHUB_GRAPHQL_API_URL } from './types'
+} from './github-api/graphql-query-factory.ts'
+import { convertEntriesToActions } from './util/entries-to-actions-converter.ts'
+import { getPathEntryFolder, getPathSchema } from './util/path-factory.ts'
+import { createEntriesFromFileContent } from './util/entry-factory.ts'
+import { handleGraphQLErrors, handleHttpErrors } from './errors.ts'
+import { getEntryContent } from './github-api/get-entry-content.ts'
+import { getFilePaths } from './github-api/get-file-paths.ts'
+import { GITHUB_GRAPHQL_API_URL } from './types.ts'
 
 export const getEntries = async (
   gitRepositoryOptions: GitHubRepositoryOptions,

--- a/src/github-api/get-entry-content.ts
+++ b/src/github-api/get-entry-content.ts
@@ -1,8 +1,8 @@
 import { AxiosCacheInstance, CacheAxiosResponse } from 'axios-cache-interceptor'
-import { GitHubRepositoryOptions } from '../index'
-import { createBlobsContentByFilePathsQuery } from './graphql-query-factory'
-import { GITHUB_GRAPHQL_API_URL, QUERY_BATCH_SIZE } from '../types'
-import { handleGraphQLErrors, handleHttpErrors } from '../errors'
+import { GitHubRepositoryOptions } from '../index.ts'
+import { createBlobsContentByFilePathsQuery } from './graphql-query-factory.ts'
+import { GITHUB_GRAPHQL_API_URL, QUERY_BATCH_SIZE } from '../types.ts'
+import { handleGraphQLErrors, handleHttpErrors } from '../errors.ts'
 
 export const getEntryContent = async (
   gitRepositoryOptions: GitHubRepositoryOptions,

--- a/src/github-api/get-file-paths.ts
+++ b/src/github-api/get-file-paths.ts
@@ -1,9 +1,9 @@
-import { GitHubRepositoryOptions } from '../index'
+import { GitHubRepositoryOptions } from '../index.ts'
 import { AxiosCacheInstance } from 'axios-cache-interceptor'
 import { ErrorCode, GitAdapterError } from '@commitspark/git-adapter'
-import { getPathEntryFolder } from '../util/path-factory'
-import { handleHttpErrors } from '../errors'
-import { GITHUB_REST_API_URL } from '../types'
+import { getPathEntryFolder } from '../util/path-factory.ts'
+import { handleHttpErrors } from '../errors.ts'
+import { GITHUB_REST_API_URL } from '../types.ts'
 
 export const getFilePaths = async (
   gitRepositoryOptions: GitHubRepositoryOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
 import { GitAdapter, CommitDraft } from '@commitspark/git-adapter'
-import { createAxiosCachedInstance } from './axios/cached-instance'
+import { createAxiosCachedInstance } from './axios/cached-instance.ts'
 import {
   createCommit,
   getEntries,
   getLatestCommitHash,
   getSchema,
-} from './github-adapter'
+} from './github-adapter.ts'
 
 export interface GitHubRepositoryOptions {
   repositoryOwner: string

--- a/src/util/entries-to-actions-converter.ts
+++ b/src/util/entries-to-actions-converter.ts
@@ -1,8 +1,8 @@
 import { EntryDraft } from '@commitspark/git-adapter'
 import { stringify } from 'yaml'
-import { AdditionModel } from '../model/addition.model'
-import { DeletionModel } from '../model/deletion.model'
-import { ENTRY_EXTENSION } from '../types'
+import { AdditionModel } from '../model/addition.model.ts'
+import { DeletionModel } from '../model/deletion.model.ts'
+import { ENTRY_EXTENSION } from '../types.ts'
 
 export function convertEntriesToActions(
   entryDrafts: EntryDraft[],

--- a/src/util/entry-factory.ts
+++ b/src/util/entry-factory.ts
@@ -1,8 +1,8 @@
 import { parse } from 'yaml'
 import { Entry } from '@commitspark/git-adapter'
-import { ENTRY_EXTENSION } from '../types'
-import { getPathEntryFolder } from './path-factory'
-import { GitHubRepositoryOptions } from '../index'
+import { ENTRY_EXTENSION } from '../types.ts'
+import { getPathEntryFolder } from './path-factory.ts'
+import { GitHubRepositoryOptions } from '../index.ts'
 
 export function createEntriesFromFileContent(
   gitRepositoryOptions: GitHubRepositoryOptions,

--- a/src/util/path-factory.ts
+++ b/src/util/path-factory.ts
@@ -1,5 +1,5 @@
-import { GitHubRepositoryOptions } from '../index'
-import { PATH_ENTRY_FOLDER, PATH_SCHEMA_FILE } from '../types'
+import { GitHubRepositoryOptions } from '../index.ts'
+import { PATH_ENTRY_FOLDER, PATH_SCHEMA_FILE } from '../types.ts'
 
 export function getPathSchema(gitRepositoryOptions: GitHubRepositoryOptions) {
   return gitRepositoryOptions.pathSchemaFile ?? PATH_SCHEMA_FILE

--- a/tsconfig.build.cjs.json
+++ b/tsconfig.build.cjs.json
@@ -2,9 +2,10 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
     "target": "es6",
     "outDir": "./dist/cjs",
-    "declarationDir": "./dist/types",
+    "declarationDir": "./dist/types"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,12 @@
 {
-   "$schema": "https://json.schemastore.org/tsconfig",
+  "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "module": "ES2015",
+    "module": "ES2022",
     "target": "ES2022",
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "esModuleInterop": true,
     "resolveJsonModule": true,
+    "rewriteRelativeImportExtensions": true,
 
     "composite": true,
     "strict": true,
@@ -16,8 +17,5 @@
     "rootDir": "./src",
     "outDir": "./dist"
   },
-  "include": [
-    "./src/**/*.ts",
-    "./tests/**/*.ts"
-  ]
+  "include": ["./src/**/*.ts", "./tests/**/*.ts"]
 }


### PR DESCRIPTION
When using commitspark in an esm environment where nodejs loads the files without any further processing from `dist/esm` this was broken due to
1. no package.json with `type: module`
2. no file-extension on the package-internal imports

This PR should fix that by adding the extensions to the imports. 
The ts setting `rewriteRelativeImportExtensions: true` converts them correctly to js in the output files.